### PR TITLE
feature: getLength()

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -7,6 +7,15 @@ const mplayer = new MPlayer();
 mplayer.openFile('/path/to/file.wav').then((item) => onItemOpen(item), (reason) => console.log(reason));
 
 const onItemOpen = (item: MPlayerMediaItem) => {
+  item.getMetadata()
+    .then(metadata => {
+      console.log('Metadata', metadata);
+      return item.getLength();
+    })
+    .then(length => {
+      console.log(`Length ${Math.floor(length / 60)}:${length % 60}`);
+    });
+
   setTimeout(() => {
     //Pause the item
     item.pause().then(() => onItemPause(item), (reason) => console.log(reason));

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -88,6 +88,25 @@ export class MPlayerMediaItem {
   }
 
   /**
+   * getLength
+   *
+   * @returns a promise that resolves with the length of file in seconds
+   */
+  public getLength(): Promise<number> {
+    if (!this.mplayer) {
+      return Promise.reject('Not in a valid state');
+    }
+
+    return this.mplayer.doCriticalOperation<number>((exec) => {
+      return exec('pausing_keep_force', 'get_property', 'length');
+    }, (data, resolve, reject) => {
+      if (data.includes('GLOBAL: ANS_length=')) {
+        resolve(parseFloat(data.match(/GLOBAL: ANS_length=([0-9\.]+)/)[1]));
+      }
+    }, DEFAULT_OP_TIMEOUT);
+  }
+
+  /**
    * getCurrentPercent
    * 
    * @returns a promise that resolves with the current percentage complete of the item

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -516,51 +516,89 @@ describe('MPlayerMediaItem.getCurrentPercent', () => {
       done(`Promise rejected: ${reason}`);
     })
   });
+});
 
-  describe('MPlayerMediaItem.getMetadata', () => {
-    let item: MPlayerMediaItem;
-    let mgr: any;
 
-    beforeEach(() => {
-      mgr = sinon.createStubInstance(MPlayerManager);
-      item = new MPlayerMediaItemTest('bob.wav', mgr);
-    });
+describe('MPlayerMediaItem.getLength', () => {
+  let item: MPlayerMediaItem;
+  let mgr: any;
 
-    it('should resolve if it succeeds', (done) => {
-      mgr.doCriticalOperation.callsFake((
-        op: (exec: (...args: (string | number)[]) => void) => void,
-        processData: (data: string, resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void,
-        timeout?: number) => {
-        return new Promise<void>((resolve, reject) => {
-
-          const opSpy = sinon.stub();
-          opSpy.returns(Promise.resolve());
-
-          op(opSpy);
-          expect(opSpy).to.have.been.calledOnce;
-          expect(opSpy.getCall(0).args[0]).to.eq('pausing_keep_force');
-          expect(opSpy.getCall(0).args[1]).to.eq('get_property');
-          expect(opSpy.getCall(0).args[2]).to.eq('metadata');
-
-          processData('GLOBAL: ANS_metadata=Title,Everything In Its Right Place ,Artist,Radiohead   ,Album,Kid A ,Year,2000   ,Comment,,Track,1,Genre,Other', resolve, reject);
-        });
-      });
-
-      item.getMetadata().then((value) => {
-        expect(value).to.eql({
-          title: 'Everything In Its Right Place',
-          artist: 'Radiohead',
-          album: 'Kid A',
-          year: 2000,
-          comment: '',
-          track: 1,
-          genre: 'Other'
-        });
-        done();
-      }, (reason) => {
-        done(`Promise rejected: ${reason}`);
-      })
-    });
+  beforeEach(() => {
+    mgr = sinon.createStubInstance(MPlayerManager);
+    item = new MPlayerMediaItemTest('bob.wav', mgr);
   });
 
+  it('should resolve if it succeeds', (done) => {
+    mgr.doCriticalOperation.callsFake((
+      op: (exec: (...args: (string | number)[]) => void) => void,
+      processData: (data: string, resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void,
+      timeout?: number) => {
+      return new Promise<void>((resolve, reject) => {
+
+        const opSpy = sinon.stub();
+        opSpy.returns(Promise.resolve());
+
+        op(opSpy);
+        expect(opSpy).to.have.been.calledOnce;
+        expect(opSpy.getCall(0).args[0]).to.eq('pausing_keep_force');
+        expect(opSpy.getCall(0).args[1]).to.eq('get_property');
+        expect(opSpy.getCall(0).args[2]).to.eq('length');
+
+        processData('GLOBAL: ANS_length=120.7', resolve, reject);
+      });
+    });
+
+    item.getLength().then((value) => {
+      expect(value).to.eq(120.7);
+      done();
+    }, (reason) => {
+      done(`Promise rejected: ${reason}`);
+    })
+  });
+});
+
+describe('MPlayerMediaItem.getMetadata', () => {
+  let item: MPlayerMediaItem;
+  let mgr: any;
+
+  beforeEach(() => {
+    mgr = sinon.createStubInstance(MPlayerManager);
+    item = new MPlayerMediaItemTest('bob.wav', mgr);
+  });
+
+  it('should resolve if it succeeds', (done) => {
+    mgr.doCriticalOperation.callsFake((
+      op: (exec: (...args: (string | number)[]) => void) => void,
+      processData: (data: string, resolve: (value?: void | PromiseLike<void>) => void, reject: (reason?: any) => void) => void,
+      timeout?: number) => {
+      return new Promise<void>((resolve, reject) => {
+
+        const opSpy = sinon.stub();
+        opSpy.returns(Promise.resolve());
+
+        op(opSpy);
+        expect(opSpy).to.have.been.calledOnce;
+        expect(opSpy.getCall(0).args[0]).to.eq('pausing_keep_force');
+        expect(opSpy.getCall(0).args[1]).to.eq('get_property');
+        expect(opSpy.getCall(0).args[2]).to.eq('metadata');
+
+        processData('GLOBAL: ANS_metadata=Title,Everything In Its Right Place ,Artist,Radiohead   ,Album,Kid A ,Year,2000   ,Comment,,Track,1,Genre,Other', resolve, reject);
+      });
+    });
+
+    item.getMetadata().then((value) => {
+      expect(value).to.eql({
+        title: 'Everything In Its Right Place',
+        artist: 'Radiohead',
+        album: 'Kid A',
+        year: 2000,
+        comment: '',
+        track: 1,
+        genre: 'Other'
+      });
+      done();
+    }, (reason) => {
+      done(`Promise rejected: ${reason}`);
+    })
+  });
 });


### PR DESCRIPTION
# Feature: getLength()

Get track length in seconds.

Request:

```
get_property length
```

Response:

```
ANS_length=217.4
```

Usage:

```
const len = await item.getLength();
```

P.S. Also you can see some mess in the test. That's because in my previous PR i put my `describe` (related to `getMetadata`) into another `describe` by accident. I fixed this problem in the current PR.

Also i have updated the `example.ts` for `getMetadata()` and `getLength()`.