### PR TITLE
MPlayerManager.prototype.setStartupVolume(vol: number)

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -442,6 +442,17 @@ export class MPlayer {
   }
 
   /**
+   * setStartupVolume
+   * 
+   * Set volume [0...100] that will be passed as `-volume` option to the new mplayer process once it is spawned
+   * 
+   * @param volume
+   */
+  public setStartupVolume(volume: number): void {
+    this.mplayer.setStartupVolume(volume);
+  }
+
+  /**
    * shutdown
    * 
    * Shutdown mplayer

--- a/src/lib/mplayerManager.ts
+++ b/src/lib/mplayerManager.ts
@@ -25,6 +25,7 @@ export class MPlayerManager {
   private mplayerProc: proc.ChildProcess;
   private ready: boolean = false;
   private busy: boolean = false;
+  private startupVolume?: number = null;
 
   /**
    * constructor
@@ -217,6 +218,18 @@ export class MPlayerManager {
     });
   }
 
+  private spawnMplayer(args: Array<string>): proc.ChildProcess {
+    return proc.spawn('mplayer', args);
+  }
+
+  private buildCommandOptions(): Array<string> {
+    const opts = [...MPLAYER_ARGS];
+    if(this.startupVolume !== null) {
+      opts.push('-volume', this.startupVolume.toString());
+    }
+    return opts;
+  }
+
   /**
    * readyMPlayer
    * 
@@ -231,7 +244,7 @@ export class MPlayerManager {
       }
 
       const spawnMPlayer = () => {
-        this.mplayerProc = proc.spawn('mplayer', MPLAYER_ARGS);
+        this.mplayerProc = this.spawnMplayer(this.buildCommandOptions());
 
         const handleProcCompletion = () => {
           if (this.mplayerProc) {
@@ -285,5 +298,19 @@ export class MPlayerManager {
 
       this.shutdown().then(spawnMPlayer, spawnMPlayer);
     });
+  }
+
+  public setStartupVolume(volume: number): void {
+    if (isNaN(volume)) {
+      volume = 0;
+    }
+    if (volume > 100) {
+      volume = 100;
+    }
+    if (volume < 0) {
+      volume = 0;
+    }
+
+    this.startupVolume = volume;
   }
 }

--- a/src/test/mplayerManager.spec.ts
+++ b/src/test/mplayerManager.spec.ts
@@ -8,6 +8,93 @@ import * as sinonChai from 'sinon-chai';
 
 const expect = chai.expect;
 
+describe('MPlayerManager.setStartupVolume', () => {
+  let mgr: MPlayerManager;
+  let spawnArgs: Array<string>;
+  beforeEach(()=>{
+    mgr = new MPlayerManager((line) => console.log(line));
+    const spawnMplayer = sinon.stub();
+    const mplayerProc = {
+      on: sinon.stub(),
+      removeListener: sinon.stub(),
+      removeAllListeners: sinon.stub(),
+      stdout: {
+        on: sinon.stub(),
+        removeListener: sinon.stub(),
+        removeAllListeners: sinon.stub(),
+      },
+      stderr: {
+        on: sinon.stub(),
+        removeListener: sinon.stub(),
+        removeAllListeners: sinon.stub(),
+      }
+    };
+    spawnMplayer.callsFake((args) => {
+      spawnArgs = args;
+      return mplayerProc;  
+    });
+    (<any>mgr).spawnMplayer = spawnMplayer;
+  });
+
+
+  it('should start mplayer with no volume argument', (done) => {
+
+    mgr.doCriticalOperation<string>((exec) => {
+      return Promise.resolve();
+    }, (data, resolve, reject) => {
+      resolve('ok');
+    }, 0);
+
+    setTimeout(()=>{
+      expect(spawnArgs).to.deep.equal([
+        '-msgmodule',
+        '-msglevel',
+        'all=6:statusline=4',
+        '-idle',
+        '-slave',
+        '-fs',
+        '-noborder',
+        '-softvol',
+        '-softvol-max',
+        '500'
+      ]);
+      done();
+    }, 10);
+  });
+
+
+  it('should start mplayer with volume argument set', (done) => {
+
+    mgr.setStartupVolume(30);
+
+    mgr.doCriticalOperation<string>((exec) => {
+      return Promise.resolve();
+    }, (data, resolve, reject) => {
+      resolve('ok');
+    }, 0);
+
+    setTimeout(()=>{
+      expect(spawnArgs).to.deep.equal([
+        '-msgmodule',
+        '-msglevel',
+        'all=6:statusline=4',
+        '-idle',
+        '-slave',
+        '-fs',
+        '-noborder',
+        '-softvol',
+        '-softvol-max',
+        '500',
+        '-volume',
+        '30'
+      ]);
+      done();
+    }, 10);
+  });
+  
+});
+
+
 describe('MPlayerManager.shutdown', () => {
 
   let mgr: MPlayerManager;


### PR DESCRIPTION
Hello Craig!

I am building a command-line player (you can see the progress here: https://github.com/jskalama and especially here: https://github.com/jskalama/kalama/tree/feature/mplayer-saga). It is built on top of your great library! I am adding the volume feature to my player, but there is a problem.

## The problem

My application remembers the user's volume setting. When i switch from one track to another, i have to restore the user's volume each time i open a new file. If i do so, there is a small interval between the playback has actually started and the volume is possible to set. Within this interval, the actual volume is set to its default value (20), and it causes bad user experience (the track is too loud or silent at the first 0.5-1 second, then the volume is set to normal).

## Workaround

«It would be nice» — i said to myself — «to shutdown the mplayer after each track and to spawn it with `-volume` option set to the user-selected value». That's what this pull request does.